### PR TITLE
feat: add About button and dialog

### DIFF
--- a/AboutWindow.xaml
+++ b/AboutWindow.xaml
@@ -1,0 +1,63 @@
+<Window x:Class="ZenDisk.AboutWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="About ZenDisk"
+        Height="250"
+        Width="300"
+        ResizeMode="NoResize"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False">
+    <Grid Margin="18">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   Text="ZenDisk"
+                   FontSize="20"
+                   FontWeight="SemiBold"
+                   Margin="0,0,0,10"/>
+
+        <TextBlock x:Name="VersionTextBlock"
+                   Grid.Row="1"
+                   Margin="0,0,0,10"/>
+
+        <TextBlock Grid.Row="2"
+                   Margin="0,0,0,8">
+            <Hyperlink NavigateUri="https://github.com/"
+                       RequestNavigate="GitHubLink_RequestNavigate">
+                <Run x:Name="RepositoryTextRun" Text="https://github.com/vlkvkn/ZenDisk"/>
+            </Hyperlink>
+        </TextBlock>
+
+        <TextBlock Grid.Row="3"
+                   Text="License: MIT License"
+                   Margin="0,0,0,8"/>
+
+        <TextBlock Grid.Row="4"
+                   Text="Contributions are more than welcome!"
+                   TextWrapping="Wrap"
+                   Margin="0,0,0,14"/>
+
+        <Border Grid.Row="7"
+                BorderBrush="#DDDDDD"
+                BorderThickness="0,1,0,0"
+                Padding="0,12,0,0">
+            <StackPanel Orientation="Horizontal"
+                        HorizontalAlignment="Right">
+                <Button Content="Close"
+                        Width="90"
+                        IsDefault="True"
+                        IsCancel="True"
+                        Click="Close_Click"/>
+            </StackPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/AboutWindow.xaml.cs
+++ b/AboutWindow.xaml.cs
@@ -1,0 +1,62 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Navigation;
+
+namespace ZenDisk;
+
+/// <summary>
+/// Interaction logic for AboutWindow.xaml
+/// </summary>
+public partial class AboutWindow : Window
+{
+    private const string RepositoryUrl = "https://github.com/vlkvkn/ZenDisk";
+
+    public AboutWindow()
+    {
+        InitializeComponent();
+
+        var version = Assembly.GetEntryAssembly()?.GetName().Version;
+        VersionTextBlock.Text = version is null
+            ? "Version: unknown"
+            : $"Version: {version.Major}.{version.Minor}.{version.Build}";
+        RepositoryTextRun.Text = RepositoryUrl;
+    }
+
+    private void Close_Click(object sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+
+    private void GitHubLink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+    {
+        OpenExternalUrl(e.Uri);
+        e.Handled = true;
+    }
+
+    private static void OpenExternalUrl(Uri? uri)
+    {
+        if (uri is null)
+        {
+            return;
+        }
+
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = uri.AbsoluteUri,
+                UseShellExecute = true
+            });
+        }
+        catch (Win32Exception)
+        {
+            MessageBox.Show(
+                "Unable to open the repository link in your browser.",
+                "Navigation Error",
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
+        }
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -128,6 +128,15 @@
                    Command="{Binding CancelScanCommand}"
                    Margin="5"
                    Padding="10,5"/>
+            <Separator/>
+            <Button Content="i"
+                   Click="ShowAbout_Click"
+                   ToolTip="About ZenDisk"
+                   Margin="5"
+                   Padding="10,5"
+                   FontWeight="Bold"
+                   MinWidth="32"
+                   AutomationProperties.Name="Open About dialog"/>
         </ToolBar>
         
         <!-- Progress Bar -->

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -57,6 +57,16 @@ public partial class MainWindow : Window
         }
     }
 
+    private void ShowAbout_Click(object sender, RoutedEventArgs e)
+    {
+        var aboutWindow = new AboutWindow
+        {
+            Owner = this
+        };
+
+        aboutWindow.ShowDialog();
+    }
+
     private void TreeView_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
     {
         if (FileSystemTreeView.SelectedItem is FileItem fileItem)


### PR DESCRIPTION
Closes #1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only addition; the only behavior change is launching the default browser via `Process.Start` when the repository hyperlink is clicked.
> 
> **Overview**
> Adds a modal **About ZenDisk** dialog accessible from a new toolbar "i" button in `MainWindow`.
> 
> The dialog shows the app version (from entry assembly), license/contribution text, and a clickable repository URL that opens in the user’s default browser with a guarded error message on failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 772d57459f04b34b347d1a433db76e65a05965a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->